### PR TITLE
Mark/build fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.9'
+    id 'org.openjfx.javafxplugin' version '0.0.5'
 }
 
 ext {
@@ -35,7 +35,7 @@ configurations {
 }
 
 dependencies {
-    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }
@@ -57,4 +57,14 @@ task copyNatives(type: Copy) {
 run {
     dependsOn copyNatives
     mainClassName = 'com.esri.samples.graphics_update.client_app.MoveGraphicsLauncher'
+}
+
+jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    manifest {
+        attributes("Main-Class": "$mainClassName")
+    }
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
+    id 'org.openjfx.javafxplugin' version '0.0.9'
 }
 
 ext {
@@ -35,7 +35,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
+    implementation "com.esri.arcgisruntime:arcgis-java:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-jnilibs:$arcgisVersion"
     natives "com.esri.arcgisruntime:arcgis-java-resources:$arcgisVersion"
 }
@@ -65,6 +65,6 @@ jar {
         attributes("Main-Class": "$mainClassName")
     }
     from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
 }


### PR DESCRIPTION
Adding a jar task with works with the latest gradle javafx plugin alongside the use of implementation instead of compile.

This adds a new way to ensure that all important parts are included in the jar.